### PR TITLE
fix: json parse when project goals not json format

### DIFF
--- a/frontend/src/graph/getProjects.js
+++ b/frontend/src/graph/getProjects.js
@@ -124,12 +124,19 @@ export function useGetProjects(chainId, daoAddress) {
   const projects = []
   if (data) {
     data.map((project) => {
+      let goals = {}
+      try {
+        goals = JSON.parse(project.goals)
+      } catch (err) {
+        console.warn("Unable to JSON parse project goals. Falling back to plaintext.", { err })
+        goals = [{goalTitle: project.goals, goalLink: '' }]
+      }
       const prj = {
         projectID: project.id.toNumber(),
         budget: ethers.utils.formatEther(project.budget),
         deadline: project.deadline,
         manager: project.manager,
-        goals: JSON.parse(project.goals)
+        goals
       }
       projects.push(prj)
     })

--- a/frontend/src/graph/getProjects.js
+++ b/frontend/src/graph/getProjects.js
@@ -128,8 +128,8 @@ export function useGetProjects(chainId, daoAddress) {
       try {
         goals = JSON.parse(project.goals)
       } catch (err) {
-        console.warn("Unable to JSON parse project goals. Falling back to plaintext.", { err })
-        goals = [{goalTitle: project.goals, goalLink: '' }]
+        console.warn('Unable to JSON parse project goals. Falling back to plaintext.', { err })
+        goals = [{ goalTitle: project.goals, goalLink: '' }]
       }
       const prj = {
         projectID: project.id.toNumber(),


### PR DESCRIPTION
When a project is submitted on-chain outside the sporosdao UI, it is possible for the project goals string to be non JSON formatted. In such case, we fall back on plain text treatment of project goals.

See screenshots for context:

<img width="558" alt="Screen Shot 2022-07-23 at 10 48 10 AM" src="https://user-images.githubusercontent.com/2234901/180596181-40d9c3b8-d1c0-4b66-9bb4-19359a4a153d.png">

<img width="1310" alt="Screen Shot 2022-07-23 at 10 45 26 AM" src="https://user-images.githubusercontent.com/2234901/180596156-c7cbb743-1c84-468a-a58f-b06f1dbdb85a.png">
<img width="564" alt="Screen Shot 2022-07-23 at 10 47 46 AM" src="https://user-images.githubusercontent.com/2234901/180596165-90d0462a-42db-4426-82fd-4056f9a77a72.png">

<img width="561" alt="Screen Shot 2022-07-23 at 10 47 57 AM" src="https://user-images.githubusercontent.com/2234901/180596174-d899de7d-1e79-4ee5-b670-f7c271d876f7.png">


Screenshot after fix:

<img width="1307" alt="Screen Shot 2022-07-23 at 10 56 57 AM" src="https://user-images.githubusercontent.com/2234901/180596175-ca1fdb65-0ebd-4e82-ba55-5816c1260009.png">


Signed-off-by: ivelin <ivelin.eth@gmail.com>